### PR TITLE
Modified Installer Procedure

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -5,15 +5,12 @@
 
 	<groupId>org.openthinclient</groupId>
 	<name>openthinclient.org server distribution</name>
-	<version>1.0.2-SNAPSHOT</version>
+	<version>${dist.version}-SNAPSHOT</version>
 
 	<artifactId>dist</artifactId>
 	<packaging>pom</packaging>
 
 	<properties>
-
-		<!-- the version of the manager modules -->
-		<manager.version>1.0.0</manager.version>
 
 		<!-- Izpack installer properties -->
 		<dist.name>openthinclient.org</dist.name>
@@ -54,64 +51,6 @@
 
 	<build>
 		<plugins>
-
-			<!-- collect all required libraries and place them in the deploy directory -->
-			<plugin>
-				<artifactId>maven-dependency-plugin</artifactId>
-
-				<executions>
-					<execution>
-						<goals>
-							<goal>copy</goal>
-						</goals>
-						<phase>package</phase>
-						<configuration>
-
-							<artifactItems>
-								<artifactItem>
-									<groupId>${project.groupId}</groupId>
-									<artifactId>manager-application-ear</artifactId>
-									<version>${manager.version}</version>
-									<type>ear</type>
-								</artifactItem>
-								<artifactItem>
-									<groupId>org.openthinclient.3rd-party.apacheds</groupId>
-									<artifactId>apacheds-server-sar</artifactId>
-									<version>${manager.version}</version>
-									<type>sar</type>
-								</artifactItem>
-								<artifactItem>
-									<groupId>org.openthinclient</groupId>
-									<artifactId>dhcp-sar</artifactId>
-									<version>${manager.version}</version>
-									<type>sar</type>
-								</artifactItem>
-								<artifactItem>
-									<groupId>org.openthinclient</groupId>
-									<artifactId>nfs-sar</artifactId>
-									<version>${manager.version}</version>
-									<type>sar</type>
-								</artifactItem>
-								<artifactItem>
-									<groupId>org.openthinclient</groupId>
-									<artifactId>syslog-sar</artifactId>
-									<version>${manager.version}</version>
-									<type>sar</type>
-								</artifactItem>
-								<artifactItem>
-									<groupId>org.openthinclient</groupId>
-									<artifactId>tftp-sar</artifactId>
-									<version>${manager.version}</version>
-									<type>sar</type>
-								</artifactItem>
-							</artifactItems>
-							<outputDirectory>../jboss/server/default/data/nfs/root/deploy/</outputDirectory>
-							<stripVersion>true</stripVersion>
-							<stripClassifier>true</stripClassifier>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 
 			<!-- build distribution -->
 			<plugin>


### PR DESCRIPTION
The manager libraries will not be downloaded anymore. Those libraries must be taken from an existing installation to ensure consistency between the installed version and the version stored in the installed packages database
